### PR TITLE
Improve SEO metadata and URLs

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -25,7 +25,7 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://safari.flit.tz/blog/how-to-get-airport-wifi-tanzania-guide</loc>
+    <loc>https://safari.flit.tz/blog/kilimanjaro-internet-guide</loc>
     <lastmod>2025-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
@@ -50,6 +50,12 @@
   </url>
   <url>
     <loc>https://safari.flit.tz/faq</loc>
+    <lastmod>2025-07-04</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://safari.flit.tz/faq/how-to-pickup-your-device</loc>
     <lastmod>2025-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
@@ -176,6 +182,12 @@
   </url>
   <url>
     <loc>https://safari.flit.tz/travel/safaris</loc>
+    <lastmod>2025-07-04</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://safari.flit.tz/wifi-rental-tanzania/airport</loc>
     <lastmod>2025-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,7 +25,8 @@ import Itineraries from './pages/Itineraries';
 import Guides from './pages/Guides';
 import Blog from './pages/Blog';
 import BlogPost from './pages/BlogPost';
-import AirportWiFiTanzania from './pages/blog/AirportWiFiTanzania';
+import KilimanjaroInternetGuide from './pages/blog/KilimanjaroInternetGuide';
+import HowToPickup from './pages/faq/HowToPickup';
 import Booking from './pages/Booking';
 
 // Travel Hub Blog
@@ -63,13 +64,15 @@ function App() {
               <Route path="/about" element={<About />} />
               <Route path="/contact" element={<Contact />} />
               <Route path="/faq" element={<FAQ />} />
+              <Route path="/faq/how-to-pickup-your-device" element={<HowToPickup />} />
               <Route path="/checkout" element={<RentalCheckout />} />
               <Route path="/airport-wifi" element={<AirportWiFi />} />
+              <Route path="/wifi-rental-tanzania/airport" element={<AirportWiFi />} />
               
               {/* Blog Routes */}
               <Route path="/blog" element={<Blog />} />
               <Route path="/blog/:slug" element={<BlogPost />} />
-              <Route path="/blog/how-to-get-airport-wifi-tanzania-guide" element={<AirportWiFiTanzania />} />
+              <Route path="/blog/kilimanjaro-internet-guide" element={<KilimanjaroInternetGuide />} />
               
               {/* Travel Content - Secondary Features */}
               <Route path="/travel" element={<Destinations />} />

--- a/src/components/SEO.jsx
+++ b/src/components/SEO.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Helmet } from 'react-helmet-async';
+
+const SEO = ({ title, description, url, image = '/logo.png', type = 'website', schema }) => (
+  <Helmet>
+    {title && <title>{title}</title>}
+    {description && <meta name="description" content={description} />}
+    {title && <meta property="og:title" content={title} />}
+    {description && <meta property="og:description" content={description} />}
+    {url && <meta property="og:url" content={url} />}
+    {image && <meta property="og:image" content={image} />}
+    <meta property="og:type" content={type} />
+    <meta name="twitter:card" content="summary_large_image" />
+    {schema && (
+      <script type="application/ld+json">{JSON.stringify(schema)}</script>
+    )}
+  </Helmet>
+);
+
+export default SEO;

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -77,8 +77,10 @@ const About = () => {
       <Helmet>
         <title>About Safari Surf WiFi - Tanzania's Leading WiFi Rental Service | Our Story</title>
         <meta name="description" content="Learn about Safari Surf WiFi, Tanzania's premier portable WiFi rental service. Join our growing customer base, 15+ cities, 99.9% uptime. Connecting Tanzania since 2020." />
-        <meta name="keywords" content="about Safari Surf WiFi, Tanzania WiFi company, portable internet rental history, WiFi rental team Tanzania, our story" />
         <link rel="canonical" href="https://safari.flit.tz/about" />
+        <meta property="og:title" content="About Safari Surf WiFi - Tanzania's Leading WiFi Rental Service" />
+        <meta property="og:description" content="Learn about Safari Surf WiFi, Tanzania's premier portable WiFi rental service." />
+        <meta property="og:url" content="https://safari.flit.tz/about" />
       </Helmet>
 
       <div className="min-h-screen">

--- a/src/pages/AirportWiFi.jsx
+++ b/src/pages/AirportWiFi.jsx
@@ -280,10 +280,12 @@ CASH ON DELIVERY AVAILABLE - I can pay when receiving the device.`;
   return (
     <>
       <Helmet>
-        <title>Get WiFi in Tanzania in Under 5 Minutes – Airport & Home Delivery | Safari Surf WiFi</title>
+        <title>Tanzania Airport WiFi Rental - Quick Pickup & Delivery | Safari Surf</title>
         <meta name="description" content="Unlimited 4G WiFi delivered at any airport, hotel, or home across Tanzania. Get connected instantly at all major Tanzania airports. Meet & greet service available." />
-        <meta name="keywords" content="airport WiFi Tanzania, JNIA WiFi rental, Dar es Salaam airport internet, Kilimanjaro airport WiFi, Zanzibar airport WiFi, travel WiFi Tanzania" />
-        <link rel="canonical" href="https://safari.flit.tz/airport-wifi" />
+        <link rel="canonical" href="https://safari.flit.tz/wifi-rental-tanzania/airport" />
+        <meta property="og:title" content="Tanzania Airport WiFi Rental - Quick Pickup & Delivery" />
+        <meta property="og:description" content="Unlimited 4G WiFi delivered at any airport, hotel, or home across Tanzania." />
+        <meta property="og:url" content="https://safari.flit.tz/wifi-rental-tanzania/airport" />
       </Helmet>
 
       <div className="min-h-screen">

--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { useInView } from 'react-intersection-observer';
 import { Calendar, User, ArrowRight, Wifi, Smartphone, Globe } from 'lucide-react';
+import SEO from '../components/SEO';
 
 const Blog = () => {
   const [heroRef, heroInView] = useInView({ triggerOnce: true, threshold: 0.1 });
@@ -100,6 +101,12 @@ const Blog = () => {
 
   return (
     <div className="min-h-screen">
+      <SEO
+        title="Safari Surf WiFi Blog - Connectivity Tips & News"
+        description="Read the latest articles on staying connected in Tanzania with portable WiFi and tech advice."
+        url="https://safari.flit.tz/blog"
+        type="article"
+      />
       {/* Hero Section */}
       <section 
         ref={heroRef}

--- a/src/pages/Coverage.jsx
+++ b/src/pages/Coverage.jsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { useInView } from 'react-intersection-observer';
 import { MapPin, CheckCircle, Clock, ArrowRight } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import SEO from '../components/SEO';
 
 const Coverage = () => {
   const [heroRef, heroInView] = useInView({ triggerOnce: true, threshold: 0.1 });
@@ -86,6 +87,11 @@ const Coverage = () => {
 
   return (
     <div className="min-h-screen">
+      <SEO
+        title="Safari Surf WiFi Coverage Map - Available Cities"
+        description="Check if Safari Surf WiFi is available in your Tanzanian destination."
+        url="https://safari.flit.tz/coverage"
+      />
       {/* Hero Section */}
       <section 
         ref={heroRef}

--- a/src/pages/FAQ.jsx
+++ b/src/pages/FAQ.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import { useInView } from 'react-intersection-observer';
 import { ChevronDown, ChevronUp, Search, HelpCircle, Phone, Mail } from 'lucide-react';
+import SEO from '../components/SEO';
 
 const FAQ = () => {
   const [searchTerm, setSearchTerm] = useState('');
@@ -126,6 +127,15 @@ const FAQ = () => {
 
   return (
     <div className="min-h-screen">
+      <SEO
+        title="Safari Surf WiFi FAQ - Get Answers to Common Questions"
+        description="Find answers about installation, plans and troubleshooting for Safari Surf WiFi services in Tanzania."
+        url="https://safari.flit.tz/faq"
+        schema={{
+          "@context": "https://schema.org",
+          "@type": "FAQPage"
+        }}
+      />
       {/* Hero Section */}
       <section 
         ref={heroRef}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
+import SEO from '../components/SEO';
 import { motion } from 'framer-motion';
 import { useInView } from 'react-intersection-observer';
 import { 
@@ -135,34 +136,30 @@ const Home = () => {
 
   return (
     <>
-      <Helmet>
-        <title>Get WiFi in Tanzania in Under 5 Minutes – Airport & Home Delivery | Safari Surf WiFi</title>
-        <meta name="description" content="Unlimited 4G WiFi delivered at any airport, hotel, or home across Tanzania. From $4.85/day or TSh 6,600 – Unlimited Usage. Get connected instantly in Tanzania!" />
-        <meta name="keywords" content="WiFi rental Tanzania, portable WiFi Tanzania, internet rental Dar es Salaam, mobile WiFi Arusha, WiFi device rental Zanzibar, Tanzania internet, safari WiFi, travel WiFi Tanzania" />
-        <link rel="canonical" href="https://safari.flit.tz" />
-        
-        {/* Enhanced Local SEO */}
-        <script type="application/ld+json">
-        {JSON.stringify({
+      <SEO
+        title="Get WiFi in Tanzania in Under 5 Minutes – Airport & Home Delivery | Safari Surf WiFi"
+        description="Unlimited 4G WiFi delivered at any airport, hotel, or home across Tanzania. From $4.85/day or TSh 6,600 – Unlimited Usage. Get connected instantly in Tanzania!"
+        url="https://safari.flit.tz"
+        schema={{
           "@context": "https://schema.org",
           "@type": "WebPage",
-          "name": "Get WiFi in Tanzania in Under 5 Minutes – Airport & Home Delivery",
-          "description": "Unlimited 4G WiFi delivered at any airport, hotel, or home across Tanzania. From $4.85/day or TSh 6,600 – Unlimited Usage.",
-          "url": "https://safari.flit.tz",
-          "mainEntity": {
+          name: "Get WiFi in Tanzania in Under 5 Minutes – Airport & Home Delivery",
+          description:
+            "Unlimited 4G WiFi delivered at any airport, hotel, or home across Tanzania. From $4.85/day or TSh 6,600 – Unlimited Usage.",
+          url: "https://safari.flit.tz",
+          mainEntity: {
             "@type": "LocalBusiness",
-            "name": "Safari Surf WiFi",
-            "priceRange": "$4.85-$150",
-            "telephone": "+255764928408",
-            "address": {
+            name: "Safari Surf WiFi",
+            priceRange: "$4.85-$150",
+            telephone: "+255764928408",
+            address: {
               "@type": "PostalAddress",
-              "addressCountry": "TZ",
-              "addressRegion": "Dar es Salaam"
+              addressCountry: "TZ",
+              addressRegion: "Dar es Salaam"
             }
           }
-        })}
-        </script>
-      </Helmet>
+        }}
+      />
 
       <div className="min-h-screen overflow-hidden">
         {/* Optimized Floating Background Elements */}

--- a/src/pages/Itineraries.jsx
+++ b/src/pages/Itineraries.jsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { useInView } from 'react-intersection-observer';
 import { MapPin, Clock, Users, Star, ArrowRight, Calendar, Camera, Mountain, Palmtree, Binary as Binoculars, Heart } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import SEO from '../components/SEO';
 
 const Itineraries = () => {
   const [selectedDuration, setSelectedDuration] = useState('all');
@@ -154,6 +155,11 @@ const Itineraries = () => {
 
   return (
     <div className="min-h-screen">
+      <SEO
+        title="Tanzania Safari Itineraries - Plan Your Adventure"
+        description="Sample itineraries for incredible safari and beach holidays across Tanzania."
+        url="https://safari.flit.tz/travel/itineraries"
+      />
       {/* Hero Section */}
       <section 
         ref={heroRef}

--- a/src/pages/Pricing.jsx
+++ b/src/pages/Pricing.jsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { useInView } from 'react-intersection-observer';
 import { CheckCircle, X, Star, ArrowRight, Zap } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import SEO from '../components/SEO';
 
 const Pricing = () => {
   const [billingCycle, setBillingCycle] = useState('monthly');
@@ -135,6 +136,17 @@ const Pricing = () => {
 
   return (
     <div className="min-h-screen">
+      <SEO
+        title="Safari Surf WiFi Pricing - Affordable Internet Plans"
+        description="Compare our daily, weekly and monthly portable WiFi rental prices."
+        url="https://safari.flit.tz/pricing"
+        schema={{
+          "@context": "https://schema.org",
+          "@type": "Product",
+          "name": "Portable WiFi Rental",
+          "offers": { "@type": "Offer", "priceCurrency": "USD", "price": "4.85" }
+        }}
+      />
       {/* Hero Section */}
       <section 
         ref={heroRef}

--- a/src/pages/Safaris.jsx
+++ b/src/pages/Safaris.jsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { useInView } from 'react-intersection-observer';
 import { Camera, MapPin, Clock, Users, Star, CheckCircle, ArrowRight, Calendar, Binary as Binoculars, Tent, Award } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import SEO from '../components/SEO';
 
 const Safaris = () => {
   const [heroRef, heroInView] = useInView({ triggerOnce: true, threshold: 0.1 });
@@ -112,6 +113,11 @@ const Safaris = () => {
 
   return (
     <div className="min-h-screen">
+      <SEO
+        title="Tanzania Safari Tours - Top Wildlife Experiences"
+        description="Browse our curated safari packages to Serengeti, Ngorongoro and beyond."
+        url="https://safari.flit.tz/travel/safaris"
+      />
       {/* Hero Section */}
       <section 
         ref={heroRef}

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import { useInView } from 'react-intersection-observer';
+import SEO from '../components/SEO';
 import { 
   Home, 
   Building, 
@@ -80,6 +81,11 @@ const Services = () => {
 
   return (
     <div className="min-h-screen">
+      <SEO
+        title="Safari Surf WiFi Services - Residential & Business Internet"
+        description="Discover our range of internet services for homes, businesses and events across Tanzania."
+        url="https://safari.flit.tz/services"
+      />
       {/* Hero Section */}
       <section 
         ref={heroRef}

--- a/src/pages/blog/KilimanjaroInternetGuide.jsx
+++ b/src/pages/blog/KilimanjaroInternetGuide.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import SEO from '../../components/SEO';
+
+const KilimanjaroInternetGuide = () => (
+  <div className="min-h-screen">
+    <SEO
+      title="Kilimanjaro Internet Guide 2025 - Stay Connected on the Mountain"
+      description="Learn how to access reliable internet on Mount Kilimanjaro. Tips for SIM cards, WiFi hotspots and satellite options for climbers."
+      url="https://safari.flit.tz/blog/kilimanjaro-internet-guide"
+      type="article"
+      schema={{
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "headline": "Kilimanjaro Internet Guide 2025 - Stay Connected on the Mountain",
+        "description": "Learn how to access reliable internet on Mount Kilimanjaro. Tips for SIM cards, WiFi hotspots and satellite options for climbers.",
+        "author": { "@type": "Organization", "name": "Safari Surf WiFi" },
+        "publisher": { "@type": "Organization", "name": "Safari Surf WiFi" },
+        "datePublished": "2025-01-01",
+        "mainEntityOfPage": "https://safari.flit.tz/blog/kilimanjaro-internet-guide"
+      }}
+    />
+    <div className="p-8 max-w-3xl mx-auto prose">
+      <h1>Kilimanjaro Internet Guide</h1>
+      <p>
+        Staying connected while climbing Africa's tallest mountain can be tricky.
+        This guide covers the best options for internet access, from local SIM
+        cards to portable WiFi rentals.
+      </p>
+    </div>
+  </div>
+);
+
+export default KilimanjaroInternetGuide;

--- a/src/pages/faq/HowToPickup.jsx
+++ b/src/pages/faq/HowToPickup.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import SEO from '../../components/SEO';
+
+const HowToPickup = () => (
+  <div className="min-h-screen p-8 max-w-3xl mx-auto prose">
+    <SEO
+      title="How to Pick Up Your WiFi Device in Tanzania"
+      description="Step-by-step instructions for collecting your Safari Surf WiFi rental at the airport or in town."
+      url="https://safari.flit.tz/faq/how-to-pickup-your-device"
+      type="article"
+      schema={{
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Where do I collect my device?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Meet our representative at the arrivals hall or arrange a hotel delivery."
+            }
+          }
+        ]
+      }}
+    />
+    <h1>How to Pick Up Your Device</h1>
+    <p>
+      After booking, you'll receive a confirmation email with pickup details. Our
+      team meets you in the arrivals area with your device ready to go.
+    </p>
+  </div>
+);
+
+export default HowToPickup;

--- a/src/pages/travel/Blog.jsx
+++ b/src/pages/travel/Blog.jsx
@@ -120,8 +120,10 @@ const TravelBlog = () => {
       <Helmet>
         <title>Travel Technology Blog - Tips for Staying Connected in Tanzania | Safari Surf WiFi</title>
         <meta name="description" content="Expert travel technology tips, digital nomad guides, and connectivity solutions for Tanzania. Learn about staying connected on safari, at beaches, and in remote areas." />
-        <meta name="keywords" content="Tanzania travel blog, Tanzania WiFi solutions, travel tech tips, digital nomad Tanzania, safari connectivity" />
         <link rel="canonical" href="https://safari.flit.tz/travel/blog" />
+        <meta property="og:title" content="Travel Technology Blog" />
+        <meta property="og:description" content="Expert travel technology tips and connectivity guides for Tanzania." />
+        <meta property="og:url" content="https://safari.flit.tz/travel/blog" />
       </Helmet>
 
       <div className="min-h-screen">

--- a/src/pages/travel/BlogPost.jsx
+++ b/src/pages/travel/BlogPost.jsx
@@ -418,6 +418,15 @@ const TravelBlogPost = () => {
         <meta property="og:image" content={post.image} />
         <meta property="og:url" content={`https://safari.flit.tz/travel/blog/${post.slug}`} />
         <meta property="og:type" content="article" />
+        <script type="application/ld+json">{JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "Article",
+          "headline": post.title,
+          "description": post.excerpt,
+          "image": post.image,
+          "author": {"@type": "Organization", "name": "Safari Surf WiFi"},
+          "mainEntityOfPage": `https://safari.flit.tz/travel/blog/${post.slug}`
+        })}</script>
       </Helmet>
 
       <div className="min-h-screen">


### PR DESCRIPTION
## Summary
- create reusable `SEO` component
- add unique metadata and OG tags on main pages
- include article and FAQ structured data
- add Kilimanjaro internet guide and pickup FAQ pages
- support SEO-friendly URL routes and update sitemap

## Testing
- `npm run sitemap`
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6867b70870448321acd36b899d33af40