### PR TITLE
Add dynamic landing pages, coverage map, and social share

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import Contact from './pages/Contact';
 import FAQ from './pages/FAQ';
 import RentalCheckout from './pages/RentalCheckout';
 import AirportWiFi from './pages/AirportWiFi';
+import WifiLanding from './pages/WifiLanding';
 
 // Travel Content - Secondary Features
 import Destinations from './pages/Destinations';
@@ -68,6 +69,7 @@ function App() {
               <Route path="/checkout" element={<RentalCheckout />} />
               <Route path="/airport-wifi" element={<AirportWiFi />} />
               <Route path="/wifi-rental-tanzania/airport" element={<AirportWiFi />} />
+              <Route path="/wifi/:slug" element={<WifiLanding />} />
               
               {/* Blog Routes */}
               <Route path="/blog" element={<Blog />} />

--- a/src/components/CoverageMap.jsx
+++ b/src/components/CoverageMap.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+
+const locations = [
+  { position: [-6.8, 39.28], name: 'Dar es Salaam' },
+  { position: [-3.3869, 36.683], name: 'Arusha' },
+  { position: [-6.1700, 35.739], name: 'Dodoma' },
+  { position: [-6.1659, 39.2026], name: 'Zanzibar' }
+];
+
+const CoverageMap = () => (
+  <MapContainer center={[-6.4, 35.3]} zoom={6} style={{ height: '400px', width: '100%' }}>
+    <TileLayer
+      attribution="&copy; OpenStreetMap contributors"
+      url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+    />
+    {locations.map((loc) => (
+      <Marker key={loc.name} position={loc.position}>
+        <Popup>{loc.name}</Popup>
+      </Marker>
+    ))}
+  </MapContainer>
+);
+
+export default CoverageMap;

--- a/src/pages/Coverage.jsx
+++ b/src/pages/Coverage.jsx
@@ -4,6 +4,7 @@ import { useInView } from 'react-intersection-observer';
 import { MapPin, CheckCircle, Clock, ArrowRight } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import SEO from '../components/SEO';
+import CoverageMap from '../components/CoverageMap';
 
 const Coverage = () => {
   const [heroRef, heroInView] = useInView({ triggerOnce: true, threshold: 0.1 });
@@ -277,39 +278,15 @@ const Coverage = () => {
             </p>
           </motion.div>
 
-          <motion.div
-            initial={{ opacity: 0, scale: 0.9 }}
-            whileInView={{ opacity: 1, scale: 1 }}
-            transition={{ duration: 0.8 }}
-            viewport={{ once: true }}
-            className="bg-white rounded-2xl shadow-lg p-8 text-center"
-          >
-            <div 
-              className="h-96 bg-gradient-to-br from-orange-100 to-yellow-100 rounded-xl flex items-center justify-center mb-8"
-              style={{
-                backgroundImage: 'url("https://images.pexels.com/photos/2376997/pexels-photo-2376997.jpeg?auto=compress&cs=tinysrgb&w=800&h=400&fit=crop")',
-                backgroundSize: 'cover',
-                backgroundPosition: 'center'
-              }}
-            >
-              <div className="bg-white/90 backdrop-blur-sm rounded-xl p-8">
-                <MapPin className="h-16 w-16 text-orange-600 mx-auto mb-4" />
-                <h3 className="text-2xl font-bold text-gray-900 mb-4">
-                  Interactive Map Coming Soon
-                </h3>
-                <p className="text-gray-600 mb-6">
-                  We're building an interactive map to help you check coverage in your exact location.
-                </p>
-                <Link
-                  to="/contact"
-                  className="bg-orange-600 text-white px-6 py-3 rounded-full font-semibold hover:bg-orange-700 transition-colors inline-flex items-center space-x-2"
-                >
-                  <span>Check Your Area</span>
-                  <ArrowRight className="h-4 w-4" />
-                </Link>
-              </div>
-            </div>
-          </motion.div>
+        <motion.div
+          initial={{ opacity: 0, scale: 0.9 }}
+          whileInView={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.8 }}
+          viewport={{ once: true }}
+          className="bg-white rounded-2xl shadow-lg p-8"
+        >
+          <CoverageMap />
+        </motion.div>
         </div>
       </section>
 

--- a/src/pages/WifiLanding.jsx
+++ b/src/pages/WifiLanding.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import SEO from '../components/SEO';
+
+const landingData = {
+  'zanzibar-airport': {
+    title: 'Zanzibar Airport WiFi Rental',
+    description: 'Get a portable WiFi device delivered to Zanzibar airport for fast internet.',
+    heading: 'Zanzibar Airport WiFi Rental'
+  },
+  'arusha-safari': {
+    title: 'Arusha Safari WiFi',
+    description: 'Stay connected during your Arusha safari with unlimited data.',
+    heading: 'Arusha Safari WiFi'
+  },
+  'dodoma-city': {
+    title: 'Dodoma City Portable WiFi',
+    description: 'Unlimited portable WiFi for exploring Dodoma city.',
+    heading: 'Dodoma City WiFi'
+  }
+};
+
+const WifiLanding = () => {
+  const { slug } = useParams();
+  const data = landingData[slug] || {
+    title: 'Portable WiFi in Tanzania',
+    description: 'Rent a portable WiFi device anywhere in Tanzania.',
+    heading: slug?.replace(/-/g, ' ')
+  };
+
+  return (
+    <div className="min-h-screen">
+      <SEO title={data.title} description={data.description} url={`https://safari.flit.tz/wifi/${slug}`} />
+      <section className="py-32 bg-gradient-to-br from-orange-600 via-red-500 to-yellow-500 text-white text-center">
+        <h1 className="text-5xl font-bold">{data.heading}</h1>
+        <p className="mt-4 text-xl max-w-2xl mx-auto">{data.description}</p>
+      </section>
+      <section className="py-16">
+        <div className="max-w-3xl mx-auto px-4 text-center space-y-6">
+          <p>Reserve your portable WiFi device for {data.heading.toLowerCase()}.</p>
+          <a href="/contact" className="inline-block bg-orange-600 hover:bg-orange-700 text-white px-6 py-3 rounded-lg font-semibold">Book Now</a>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default WifiLanding;

--- a/src/pages/travel/BlogPost.jsx
+++ b/src/pages/travel/BlogPost.jsx
@@ -21,6 +21,7 @@ import {
   Map
 } from 'lucide-react';
 import toast from 'react-hot-toast';
+import { FacebookShareButton, TwitterShareButton, WhatsappShareButton } from 'react-share';
 import VisitorCounter from '../../components/VisitorCounter';
 
 // Mock blog posts data
@@ -382,28 +383,12 @@ const TravelBlogPost = () => {
     .filter(p => p.category === post.category || (p.tags && post.tags && p.tags.some(tag => post.tags.includes(tag))))
     .slice(0, 3);
   
-  const handleShare = (platform) => {
-    const url = window.location.href;
-    const text = `Check out this article: ${post.title}`;
-    
-    let shareUrl;
-    switch (platform) {
-      case 'facebook':
-        shareUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`;
-        break;
-      case 'twitter':
-        shareUrl = `https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}&text=${encodeURIComponent(text)}`;
-        break;
-      case 'copy':
-        navigator.clipboard.writeText(url)
-          .then(() => toast.success('Link copied to clipboard'))
-          .catch(() => toast.error('Failed to copy link'));
-        return;
-      default:
-        return;
-    }
-    
-    window.open(shareUrl, '_blank');
+  const shareUrl = `${window.location.origin}/travel/blog/${post.slug}`;
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(shareUrl)
+      .then(() => toast.success('Link copied to clipboard'))
+      .catch(() => toast.error('Failed to copy link'));
   };
 
   return (
@@ -576,22 +561,35 @@ const TravelBlogPost = () => {
                     <span>Share This Article</span>
                   </h3>
                   <div className="flex space-x-2">
-                    <button
-                      onClick={() => handleShare('facebook')}
-                      className="w-full bg-blue-600 text-white p-2 rounded-lg hover:bg-blue-700 transition-colors"
-                      aria-label="Share on Facebook"
+                    <FacebookShareButton
+                      url={`${shareUrl}?utm_source=facebook&utm_medium=social&utm_campaign=blog_share`}
+                      quote={post.title}
+                      className="w-full"
                     >
-                      <Facebook className="h-5 w-5 mx-auto" />
-                    </button>
-                    <button
-                      onClick={() => handleShare('twitter')}
-                      className="w-full bg-sky-500 text-white p-2 rounded-lg hover:bg-sky-600 transition-colors"
-                      aria-label="Share on Twitter"
+                      <div className="bg-blue-600 text-white p-2 rounded-lg hover:bg-blue-700 transition-colors">
+                        <Facebook className="h-5 w-5 mx-auto" />
+                      </div>
+                    </FacebookShareButton>
+                    <TwitterShareButton
+                      url={`${shareUrl}?utm_source=twitter&utm_medium=social&utm_campaign=blog_share`}
+                      title={post.title}
+                      className="w-full"
                     >
-                      <Twitter className="h-5 w-5 mx-auto" />
-                    </button>
+                      <div className="bg-sky-500 text-white p-2 rounded-lg hover:bg-sky-600 transition-colors">
+                        <Twitter className="h-5 w-5 mx-auto" />
+                      </div>
+                    </TwitterShareButton>
+                    <WhatsappShareButton
+                      url={`${shareUrl}?utm_source=whatsapp&utm_medium=social&utm_campaign=blog_share`}
+                      title={post.title}
+                      className="w-full"
+                    >
+                      <div className="bg-green-500 text-white p-2 rounded-lg hover:bg-green-600 transition-colors">
+                        <MessageCircle className="h-5 w-5 mx-auto" />
+                      </div>
+                    </WhatsappShareButton>
                     <button
-                      onClick={() => handleShare('copy')}
+                      onClick={handleCopy}
                       className="w-full bg-gray-600 text-white p-2 rounded-lg hover:bg-gray-700 transition-colors"
                       aria-label="Copy link"
                     >


### PR DESCRIPTION
## Summary
- add a dynamic `WifiLanding` page and route
- implement a Leaflet-based `CoverageMap` component and use it on coverage page
- enable social sharing on travel blog posts with Facebook, Twitter, and WhatsApp buttons

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6867b97d410c83219a8ec1d8150ac43f